### PR TITLE
removed '\t' in schema- not allowed with yaml

### DIFF
--- a/abuse_bot-infection_0.1.0.json
+++ b/abuse_bot-infection_0.1.0.json
@@ -55,11 +55,11 @@
             "format":"uri",
             "optional":true
         },
-	"Bot-Name":{
-	     "type":"string"
-	},
-	"Malware-MD5":{
-     	     "type":"string",
+        "Bot-Name":{
+            "type":"string"
+        },
+        "Malware-MD5":{
+          "type":"string",
              "optional":true
          },
         "Attachment":{


### PR DESCRIPTION
There were some "\t" in the schema (visible in vi with :set list); that hindered yaml to parse the schema.

schema yaml.load failed while scanning for the next token
found character '\t' that cannot start any token
  in "<string>", line 58, column 1:
        "Bot-Name":{
    ^